### PR TITLE
Fix casing on path string

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,7 +20,7 @@ exports.createPages = async ({ graphql, actions }) => {
   pages.data.allPrismicPost.nodes.forEach((page) => {
     createPage({
       path: page.url,
-      component: path.resolve(__dirname, 'src/templates/Post.js'),
+      component: path.resolve(__dirname, 'src/templates/post.js'),
       context: { ...page },
     })
   })


### PR DESCRIPTION
Fixes this warning when running `gatsby develop`

```
warn Your site's "gatsby-node.js" created a page with a component path that doesn't match the casing of the actual file. This may work locally, but will break
on systems which are case-sensitive, e.g. most CI/CD pipelines.

page.component:     "C:/Users/alexr/repos/gatsby-blog/src/templates/Post.js"
path in filesystem: "C:/Users/alexr/repos/gatsby-blog/src/templates/post.js"
```